### PR TITLE
Rewrite replace method to use find/replace object, update "find" criteria

### DIFF
--- a/data/replacer.js
+++ b/data/replacer.js
@@ -2,8 +2,11 @@ var replacements = { // find: replace
 	'Make America Great Again': 'Make Donald Drumpf Again',
 	'MakeAmericaGreatAgain': 'MakeDonaldDrumpfAgain',
 	'makeamericagreatagain': 'makedonalddrumpfagain',
-	'realDonaldTrump': 'RealDonalDrumpf',
-	'realdonaldtrump': 'RealDonalDrumpf',
+	'@realDonaldTrump': '@RealDonalDrumpf', // Twitter handle
+	'@realdonaldtrump': '@RealDonalDrumpf', // Twitter handle
+	'RealDonaldTrump': 'RealDonaldDrumpf',
+	'realDonaldTrump': 'realDonaldDrumpf',
+	'realdonaldtrump': 'realdonalddrumpf',
 	'DonaldTrump': 'DonaldDrumpf',
 	'donaldtrump': 'donalddrumpf',
 	'DonaldJTrump': 'DonaldJDrumpf',

--- a/data/replacer.js
+++ b/data/replacer.js
@@ -1,4 +1,19 @@
+var replacements = { // find: replace
+	'Make America Great Again': 'Make Donald Drumpf Again',
+	'MakeAmericaGreatAgain': 'MakeDonaldDrumpfAgain',
+	'makeamericagreatagain': 'makedonalddrumpfagain',
+	'realDonaldTrump': 'RealDonalDrumpf',
+	'realdonaldtrump': 'RealDonalDrumpf',
+	'DonaldTrump': 'DonaldDrumpf',
+	'donaldtrump': 'donalddrumpf',
+	'DonaldJTrump': 'DonaldJDrumpf',
+	'donaldjtrump': 'donaldjdrumpf',
+	'TRUMP': 'DRUMPF',
+	'Trump': 'Drumpf',
+	'trump': 'drumpf'
+}
+var find = Object.keys(replacements).join('|');
 var textNode, walk=document.createTreeWalker(document,NodeFilter.SHOW_TEXT,null,false);
 while(textNode=walk.nextNode()) {
-    textNode.nodeValue = textNode.nodeValue.replace(/trump/g, 'drumpf').replace(/Trump/g, 'Drumpf');
+	textNode.nodeValue = textNode.nodeValue.replace(new RegExp(find,'g'),function(match){return replacements[match];});
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Drumpfinator Make Trump Drumpf Again",
   "name": "drumpfinator_trump",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Add this to your browser and replace all instances of Trump with Drumpf.",
   "main": "index.js",
   "author": "Nishanth Vijayan",


### PR DESCRIPTION
I've updated the rewrite method to use a find/replace object instead of a series of chained "replace" declarations, for legibility, ease of modification, and speed.

I've also expanded the "find" criteria, as suggested by @spiltcoffee in #2, and revised the search order so the longer replacements are prioritized.

Fixes #2.
